### PR TITLE
FaeNet embedding refactor

### DIFF
--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -510,9 +510,6 @@ class FAENet(AbstractPyGModel):
         else:
             preds = self(batch)
 
-        if preds["energy"].shape[-1] == 1:
-            preds["energy"] = preds["energy"].view(-1)
-
         return preds["energy"]
 
     def forces_as_energy_grad(self, pos, energy):

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -446,10 +446,11 @@ class FAENet(AbstractPyGModel):
             e_all, f_all, gt_all = [], [], []
 
             # Compute model prediction for each frame
-            for i in range(len(batch.fa_pos)):
-                batch.pos = batch.fa_pos[i]
+            for frame_idx, frame in enumerate(batch.fa_pos):
+                # set positions to current frame
+                batch.pos = frame
                 if crystal_task:
-                    batch.cell = batch.fa_cell[i]
+                    batch.cell = batch.fa_cell[frame_idx]
                 # Forward pass
                 preds = self.first_forward(deepcopy(batch))
                 if not self.pred_as_dict:
@@ -461,7 +462,7 @@ class FAENet(AbstractPyGModel):
                 # Force predictions are rotated back to be equivariant
                 if preds.get("forces") is not None:
                     fa_rot = torch.repeat_interleave(
-                        batch.fa_rot[i],
+                        batch.fa_rot[frame_idx],
                         batch.natoms,
                         dim=0,
                     )
@@ -478,7 +479,7 @@ class FAENet(AbstractPyGModel):
                 if preds.get("forces_grad_target") is not None:
                     if fa_rot is None:
                         fa_rot = torch.repeat_interleave(
-                            batch.fa_rot[i],
+                            batch.fa_rot[frame_idx],
                             batch.natoms,
                             dim=0,
                         )

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -428,10 +428,15 @@ class FAENet(AbstractPyGModel):
         crystal_task = True
         batch = graph
 
-        if isinstance(batch, list):
-            batch = batch[0]
         if not hasattr(batch, "natoms"):
             batch.natoms = torch.unique(batch.batch, return_counts=True)[1]
+
+        # check that frame averaging properties are available
+        for key in ["fa_pos", "fa_cell", "fa_rot"]:
+            if not hasattr(batch, key):
+                raise KeyError(
+                    f"Graph is expected to have property {key}: include frame averaging transform!",
+                )
 
         # Distinguish Frame Averaging prediction from traditional case.
         if frame_averaging and frame_averaging != "DA":

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -268,7 +268,7 @@ class FAENet(AbstractPyGModel):
         if self.decoder:
             return self.decoder(preds["hidden_state"])
 
-    def energy_forward(self, data, preproc=True) -> torch.Tensor:
+    def energy_forward(self, data, preproc=True) -> Embeddings:
         """Predicts any graph-level property (e.g. energy) for 3D atomic systems.
 
         Args:
@@ -329,8 +329,11 @@ class FAENet(AbstractPyGModel):
         # Atom skip-co
         if self.skip_co == "concat_atom":
             energy_skip_co.append(h)
-            h = self.act(self.mlp_skip_co(torch.cat(energy_skip_co, dim=1)))
-        return h
+            node_embedding = self.act(self.mlp_skip_co(torch.cat(energy_skip_co, dim=1)))
+        else:
+            node_embedding = h
+        graph_embedding = self.output_block(node_embedding, edge_index, edge_weight, batch, alpha)
+        return Embeddings(graph_embedding, node_embedding)
 
     def first_forward(
         self,

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -256,7 +256,8 @@ class FAENet(AbstractPyGModel):
     def forces_forward(self, preds):
         """Predicts forces for 3D atomic systems.
         Can be utilised to predict any atom-level property.
-
+        
+        TODO remove this as it is no longer needed
         Args:
             preds (dict): dictionnary with final atomic representations
                 (hidden_state) and predicted properties (e.g. energy)
@@ -504,6 +505,8 @@ class FAENet(AbstractPyGModel):
 
     def forces_as_energy_grad(self, pos, energy):
         """Computes forces from energy gradient
+
+        TODO remove this as it's no longer needed
 
         Args:
             pos (tensor): 3D atom positions

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -10,9 +10,7 @@ import torch
 from torch import nn
 from torch.nn import Linear
 
-from matsciml.common.types import AbstractGraph, Embeddings
-from matsciml.common.types import BatchDict
-from matsciml.common.types import DataDict
+from matsciml.common.types import AbstractGraph, BatchDict, DataDict, Embeddings
 from matsciml.common.utils import radius_graph_pbc
 from matsciml.models.base import AbstractPyGModel
 from matsciml.models.pyg.faenet.helper import *
@@ -329,10 +327,18 @@ class FAENet(AbstractPyGModel):
         # Atom skip-co
         if self.skip_co == "concat_atom":
             energy_skip_co.append(h)
-            node_embedding = self.act(self.mlp_skip_co(torch.cat(energy_skip_co, dim=1)))
+            node_embedding = self.act(
+                self.mlp_skip_co(torch.cat(energy_skip_co, dim=1)),
+            )
         else:
             node_embedding = h
-        graph_embedding = self.output_block(node_embedding, edge_index, edge_weight, batch, alpha)
+        graph_embedding = self.output_block(
+            node_embedding,
+            edge_index,
+            edge_weight,
+            batch,
+            alpha,
+        )
         return Embeddings(graph_embedding, node_embedding)
 
     def first_forward(

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -337,7 +337,9 @@ class FAENet(AbstractPyGModel):
         graph: AbstractGraph,
         **kwargs,
     ) -> torch.Tensor:
-        """Main Forward pass.
+        """
+        Actually flowing data through architecture. First we predict
+        the energy, and optionally gradients.
 
         Args:
             data (Data): input data object, with 3D atom positions (pos)


### PR DESCRIPTION
This PR changes the mode of operation for FaeNet, mainly modifying the `_forward` -> `first_forward` and `energy_forward` methods to emit the `Embeddings` data structure now.

This leaves a **separate PR needed** to make force regression work as a frame averaging task, or to refactor the existing code base to support _lists_ of `Embeddings` being passed into `OutputHead`s. We can remove the commented out blocks then as well.

Because of the nature of this change, I've also added the hyperparameter `average_frame_embeddings`, where we average the lists of embeddings (and return a single set of embeddings). There is a modeling difference to this, as predicting then averaging might not commute with averaging then predicting: I haven't really thought this one through and we might need to test it.