### PR TITLE
Cleaning up FAENet and refactoring tasks to support frame averaging

### DIFF
--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1309,6 +1309,8 @@ class ForceRegressionTask(BaseTaskModule):
             else:
                 # assume point cloud otherwise
                 pos: torch.Tensor = batch.get("pos")
+                # no frame averaging architecture yet for point clouds
+                fa_rot = None
             if pos is None:
                 raise ValueError(
                     f"No atomic positions were found in batch - neither as standalone tensor nor graph."
@@ -1325,11 +1327,11 @@ class ForceRegressionTask(BaseTaskModule):
                 embeddings = batch.get("embeddings")
             else:
                 embeddings = self.encoder(batch)
-            outputs = self.process_embedding(embeddings, pos)
+            outputs = self.process_embedding(embeddings, pos, fa_rot)
         return outputs
 
     def process_embedding(
-        self, embeddings: Embeddings, pos: torch.Tensor
+        self, embeddings: Embeddings, pos: torch.Tensor, fa_rot: Union[None, torch.Tensor] = None
     ) -> Dict[str, torch.Tensor]:
         outputs = {}
         energy = self.output_heads["energy"](embeddings.system_embedding)

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1296,7 +1296,13 @@ class ForceRegressionTask(BaseTaskModule):
         with dynamic_gradients_context(True, self.has_rnn):
             # first ensure that positions tensor is backprop ready
             if "graph" in batch:
-                pos: torch.Tensor = batch["graph"].ndata.get("pos")
+                graph = batch["graph"]
+                # the DGL case
+                if hasattr(graph, "ndata"):
+                    pos: torch.Tensor = graph.ndata.get("pos")
+                else:
+                    # otherwise assume it's PyG
+                    pos: torch.Tensor = graph.pos
             else:
                 # assume point cloud otherwise
                 pos: torch.Tensor = batch.get("pos")

--- a/matsciml/models/base.py
+++ b/matsciml/models/base.py
@@ -1300,9 +1300,12 @@ class ForceRegressionTask(BaseTaskModule):
                 # the DGL case
                 if hasattr(graph, "ndata"):
                     pos: torch.Tensor = graph.ndata.get("pos")
+                    # for frame averaging
+                    fa_rot = graph.ndata.get("fa_rot", None)
                 else:
                     # otherwise assume it's PyG
                     pos: torch.Tensor = graph.pos
+                    fa_rot = getattr(graph, "fa_rot", None)
             else:
                 # assume point cloud otherwise
                 pos: torch.Tensor = batch.get("pos")

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -255,7 +255,9 @@ class FAENet(AbstractPyGModel):
         data["graph"].edge_index = edge_index
         data["graph"].cell_offsets = cell_offsets
         data["graph"].neighbors = neighbors
-        atomic_numbers, batch, edge_index, rel_pos, edge_weight = self.get_embed_inputs(data['graph'])
+        atomic_numbers, batch, edge_index, rel_pos, edge_weight = self.get_embed_inputs(
+            data["graph"]
+        )
         edge_attr = self.distance_expansion(edge_weight)  # RBF of pairwise distances
         node_embeddings = self.atom_embedding(atomic_numbers, rel_pos, edge_attr)
         # optionally can fuse into a single tensor with `self.join_position_embeddings`
@@ -415,12 +417,20 @@ class FAENet(AbstractPyGModel):
             batch.pos = original_pos
             batch.cell = original_cell
             # now stack up embeddings into a single tensor
-            node_embeddings = torch.stack([frame.point_embedding for frame in all_embeddings], dim=1)
-            graph_embeddings = torch.stack([frame.system_embedding for frame in all_embeddings], dim=1)
+            node_embeddings = torch.stack(
+                [frame.point_embedding for frame in all_embeddings], dim=1
+            )
+            graph_embeddings = torch.stack(
+                [frame.system_embedding for frame in all_embeddings], dim=1
+            )
             # if we're averaging the frame embeddings directly
             if self.average_frame_embeddings:
-                node_embeddings = reduce(node_embeddings, "b f h -> b h", reduction="mean")
-                graph_embeddings = reduce(graph_embeddings, "b f h -> b h", reduction="mean")
+                node_embeddings = reduce(
+                    node_embeddings, "b f h -> b h", reduction="mean"
+                )
+                graph_embeddings = reduce(
+                    graph_embeddings, "b f h -> b h", reduction="mean"
+                )
             all_embeddings = Embeddings(graph_embeddings, node_embeddings)
 
         # Traditional case (no frame averaging)

--- a/matsciml/models/pyg/faenet/faenet.py
+++ b/matsciml/models/pyg/faenet/faenet.py
@@ -244,7 +244,6 @@ class FAENet(AbstractPyGModel):
             data[key] = getattr(graph, key, None)
         pos: torch.Tensor = getattr(graph, "pos")
         data["pos"] = pos
-        # data = super().read_batch(batch)
         data["graph"].cell = batch["cell"]
         data["graph"].natoms = batch["natoms"].squeeze(-1).to(torch.int32)
         edge_index, cell_offsets, neighbors = radius_graph_pbc(


### PR DESCRIPTION
This PR should hopefully close the loop on the end-to-end compatibility with FAENet, particularly by refactoring existing tasks to allow multidimensional embeddings. 

At a high level, the FAENet architecture in `matsciml` produces an embedding for every frame, i.e. `node_embeddings` and `graph_embeddings` have a shape of `[N, F, D]` and `[B, F, D]` for `N` nodes, `B` batch, `F` frames, and `D` dimensionality. This changes allows the rest of the pipeline to be more or less the same as before, with the main change being `process_embedding` will also do a `einops.reduce` step (to make things look cleaner) on the outputs: if there are `F` frames (and actually any more dimensions beyond the first and last dimension), we will average over them. If there aren't, nothing happens and the pipeline should be backwards compatible.

This did require a major change to the `ForceRegressionTask` and `GradFreeForceRegressionTask`s, as we need to pass the rotation matrices to re-project the forces in order to preserve equivariance. For these two tasks, `fa_rot` is a new optional argument that is retrieved in the `forward` call, where if it's available, we will do the rotation on the predicted forces. The same averaging as the other tasks is done after this rotation, which is how the original FAENet worked.